### PR TITLE
SEO suggestions

### DIFF
--- a/pp-cljs-client/public/about.html
+++ b/pp-cljs-client/public/about.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en-us">
+  <head>
+    <meta charset="utf-8" />
+    <meta content="IE=edge" http-equiv="X-UA-Compatible" />
+    <title>pretty print EDN and Clojure</title>
+    <meta content="width=device-width" name="viewport" />
+  </head>
+
+  <body>
+    <h2>Rationale</h2>
+    <div>
+      <a href="https://github.com/edn-format/edn">EDN</a> is a powerful data interchange format commonly used with Clojure and ClojureScript programs. It also doubles as a literal representation of most Clojure data structures, which are often printed to a REPL or console environment for debugging purposes.
+
+      Clojure core comes with clojure.pprint - which is a library to format Clojure code (and thus EDN) in a human-readable fashion.
+
+      As of January 2015, there are numerous online services to pretty print various data interchange formats (JSON, YAML, XML, etc), but there is no online service for printing an EDN string.
+
+      This project aims to build such a service and improve the usability of working with EDN data.
+    </div>
+  </body>
+</html>

--- a/pp-cljs-client/src-cljs/pp_client/html.cljs
+++ b/pp-cljs-client/src-cljs/pp_client/html.cljs
@@ -46,7 +46,7 @@
 
 (def github-url "https://github.com/comamitc/pretty-print.net")
 (def issues-url "https://github.com/comamitc/pretty-print.net/issues")
-(def docs-url "https://github.com/comamitc/pretty-print.net/blob/master/README.md")
+(def docs-url "/about.html")
 
 (quiescent/defcomponent footer-docs-list []
   (sablono/html

--- a/pp-cljs-client/src-cljs/pp_client/html.cljs
+++ b/pp-cljs-client/src-cljs/pp_client/html.cljs
@@ -184,6 +184,9 @@
       [:div.body-outer-7cb5e
             [:div.body-inner-40af1
               [:h2.instructions-b15d3 (str "Paste " (:desc state) ":")]
+              [:div
+               "Paste EDN data or Clojure code below to have it validated and properly formatted"
+               ]
               (LeftBody state)
               (RightBody state) 
               [:div.clr-217e3]]]


### PR DESCRIPTION
A couple of things off the top of my head regarding #14:
- Use the description and website field for the repository to create a logical "crawl" for robots, like I have [here](https://github.com/NPrescott/pretty-print.net)
- Think about following up on [posts like this](http://stackoverflow.com/questions/17829584/is-there-an-online-tool-to-auto-indent-and-format-clojure-code-like-there-are-ma), "Following up 2 years later - there is now [http://pretty-print.net](http://pretty-print.net) for this very purpose" or similar.
- Instead of linking to the Github "rationale" create an _about_ or _rationale_ page on pretty-print.net itself with that information
- Add a bit of text or instruction to the main application page itself to increase any possible "content" scoring. `Paste EDN data or Clojure code below to have it validated and properly formatted` (I notice you don't mention validation but the formatter doesn't seem to work presently with invalid Clojure code)

The actual commits aren't styled at all and are instead just to give an idea of what I'm talking about.
