### PR TITLE
Consolidate project.clj definitions

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,6 @@
-(defproject pp "0.1.0-SNAPSHOT"
+(def project-version "0.2.0")
+
+(defproject pp project-version
 
   :description "A Clojure(Script) Pretty Printer"
   :url "http://pretty-print.net/"
@@ -52,6 +54,7 @@
                                 :compiler {:main pp.client.core
                                            :output-to "public/js/pretty-print.js"
                                            :output-dir "public/js/out"
+                                           :closure-defines {pp.client.data/app-v ~project-version}
                                            :asset-path "js/out"}}
 
                        :client-min {:source-paths ["src/pp/client"]
@@ -59,6 +62,7 @@
                                                :output-to "public/js/pretty-print.min.js"
                                                :output-dir "public/js/out-min"
                                                :optimizations :advanced
+                                               :closure-defines {pp.client.data/app-v ~project-version}
                                                :pretty-print false}}
                        :server {:source-paths ["src/pp/server"]
                                 :figwheel true

--- a/src/pp/client/data.cljs
+++ b/src/pp/client/data.cljs
@@ -1,9 +1,12 @@
 (ns pp.client.data
   (:require
     [ajax.core :refer [GET POST]]
-    [pp.client.util :refer [js-log log]]))
+    [pp.client.util :refer [js-log log]]
+    [goog.crypt.base64 :as b64]))
 
-(def id "9c9fc")
+(goog-define app-v "0.0.0")
+
+(def id (b64/encodeString app-v))
 
 (defn format-input [state handler error-handler]
   (POST (:uri state) {:params {:input (:value state)


### PR DESCRIPTION
Now that the JVM server will be removed per https://github.com/comamitc/pretty-print.net/pull/34, I will be able to combine the project.clj files into one root level configuration similar to: https://github.com/comamitc/cljs-proj/blob/master/project.clj.

In addition, we should look to manage my node dependencies via `lein-npm` instead of a separate `package.json` definition.

So the action items are:
- [x] Combine client and server `project.clj` files into one root level config
- [x] Move node dependencies to `project.clj` using `lein-npm
- [x] Use figwheel to drive dev workflow instead of several different node _dev-servers_ that are currently needed.  (this will probably include removing grunt in favor of other `lein` plugins as well)
